### PR TITLE
Fix variance component ordering in vcov.lmerMod/estfun.lmerMod (#2) and add regression tests for estfun.glmerMod subscript error (#3)

### DIFF
--- a/R/estfun.lmerMod.R
+++ b/R/estfun.lmerMod.R
@@ -45,8 +45,13 @@ estfun.lmerMod <- function(x, ...) {
   M <- solve(chol(V))
   invV <- tcrossprod(M, M)
   yXbesoV <- crossprod(yXbe, invV)
-  LambdaInd <- parts$Lambda
+  ## Lind maps theta into the slots of Lambdat (not Lambda), so fill
+  ## Lambdat with the parameter indices and transpose; assigning Lind
+  ## directly into Lambda@x scrambles parameters when a random-effect
+  ## block is 3x3 or larger.
+  LambdaInd <- parts$Lambdat
   LambdaInd@x[] <- parts$Lind
+  LambdaInd <- t(LambdaInd)
   invVX <- crossprod(parts$X, invV)
   Pmid <- solve(crossprod(parts$X, t(invVX)))
   P <- invV - tcrossprod(crossprod(invVX, Pmid), t(invVX))

--- a/R/vcov.lmerMod.R
+++ b/R/vcov.lmerMod.R
@@ -34,8 +34,13 @@ vcov.lmerMod <- function(object, ...) {
   V <- (tcrossprod(Zlam, Zlam) + Diagonal(parts$n, 1)) * (parts$sigma)^2
   M <- solve(chol(V))
   invV <- tcrossprod(M, M)
-  LambdaInd <- parts$Lambda
-  LambdaInd@x[] <- parts$Lind 
+  ## Lind maps theta into the slots of Lambdat (not Lambda), so fill
+  ## Lambdat with the parameter indices and transpose; assigning Lind
+  ## directly into Lambda@x scrambles parameters when a random-effect
+  ## block is 3x3 or larger.
+  LambdaInd <- parts$Lambdat
+  LambdaInd@x[] <- parts$Lind
+  LambdaInd <- t(LambdaInd)
   invVX <- crossprod(parts$X, invV)
   Pmid <- solve(crossprod(parts$X, t(invVX)))
   P <- invV - tcrossprod(crossprod(invVX, Pmid), t(invVX))
@@ -93,12 +98,12 @@ vcov.lmerMod <- function(object, ...) {
           tcrossprod(crossprod(P, devV[[x[1]]]), P), t(devV[[x[2]]])))))
       }
       if(information == "observed") {
-        ranhes[lower.tri(ranhes, diag = TRUE)] <- apply(entries, 1, 
-          function(x) -as.numeric((1/2) * lav_matrix_trace(
-          tcrossprod(tcrossprod(crossprod(P, devV[[x[1]]]), P), 
+        ranhes[lower.tri(ranhes, diag = TRUE)] <- apply(entries, 1,
+          function(x) as.vector(-as.numeric((1/2) * lav_matrix_trace(
+          tcrossprod(tcrossprod(crossprod(P, devV[[x[1]]]), P),
           t(devV[[x[2]]])))) + tcrossprod((tcrossprod((crossprod(
           yXbe, tcrossprod(tcrossprod(crossprod(invV,
-          devV[[x[1]]]), P), t(devV[[x[2]]])))), invV)), t(yXbe)))             
+          devV[[x[1]]]), P), t(devV[[x[2]]])))), invV)), t(yXbe))))
       }      
     }
     ranhes <- forceSymmetric(ranhes, uplo = "L")

--- a/inst/tinytest/test-github-issues.R
+++ b/inst/tinytest/test-github-issues.R
@@ -1,0 +1,77 @@
+library("lme4")
+
+## Github issue #2: with 3 or more random effects per grouping factor,
+## the variance component block of vcov(., full = TRUE) and the
+## variance component columns of estfun() came back in an order that
+## did not match their labels, so results depended on the order in
+## which random effects were entered in the formula.
+set.seed(42)
+J <- 60; nj <- 10; N <- J * nj
+G <- matrix(c(4, 1, .8,  1, 2, .5,  .8, .5, 1.5), 3, 3)
+Gchol <- chol(G)
+simd <- data.frame(g = rep(1:J, each = nj), x1 = rnorm(N), x2 = rnorm(N))
+re <- matrix(rnorm(J * 3), J, 3) %*% Gchol
+simd$y <- 2 + .5 * simd$x1 - .3 * simd$x2 + re[simd$g, 1] +
+  re[simd$g, 2] * simd$x1 + re[simd$g, 3] * simd$x2 + rnorm(N, 0, 1.5)
+
+fit1 <- lmer(y ~ x1 + x2 + (x1 + x2 | g), simd, REML = FALSE)
+fit2 <- lmer(y ~ x1 + x2 + (x2 + x1 | g), simd, REML = FALSE)
+
+## map parameter names of fit2 onto fit1 (covariance labels may have
+## their two variable names in either order, so compare sorted labels)
+normnames <- function(v) {
+  ifelse(grepl("^cov_g\\.", v),
+         paste0("VC:", sapply(strsplit(sub("^cov_g\\.", "", v), "\\.",
+                                       fixed = FALSE),
+                              function(s) paste(sort(s), collapse = "+"))),
+         v)
+}
+
+for (info in c("expected", "observed")) {
+  V1 <- as.matrix(vcov(fit1, full = TRUE, information = info))
+  V2 <- as.matrix(vcov(fit2, full = TRUE, information = info))
+  idx <- match(normnames(colnames(V1)), normnames(colnames(V2)))
+  expect_false(any(is.na(idx)))
+  expect_equal(V1, V2[idx, idx], check.attributes = FALSE, tolerance = 1e-3,
+               info = paste("vcov consistency across RE orderings,", info))
+}
+
+S1 <- estfun(fit1)
+S2 <- estfun(fit2)
+idx <- match(normnames(colnames(S1)), normnames(colnames(S2)))
+expect_equal(unname(as.matrix(S1)), unname(as.matrix(S2))[, idx],
+             check.attributes = FALSE, tolerance = 1e-3,
+             info = "estfun consistency across RE orderings")
+
+## the variance component block must also be correctly labeled: the
+## diagonal variance entries follow theta order (column-major lower
+## triangle), so the entry labeled cov_g.x1 must be the sampling
+## variance of the x1 random effect variance, which is invariant to
+## formula order once matched by label.
+v1 <- diag(as.matrix(vcov(fit1, full = TRUE)))
+v2 <- diag(as.matrix(vcov(fit2, full = TRUE)))
+expect_equal(v1["cov_g.x1"], v2["cov_g.x1"], tolerance = 1e-3,
+             check.attributes = FALSE)
+expect_equal(v1["cov_g.x2"], v2["cov_g.x2"], tolerance = 1e-3,
+             check.attributes = FALSE)
+
+## Github issue #3: estfun.glmerMod() failed with "subscript out of
+## bounds" when cluster ids were numeric but not consecutive integers
+## starting at 1 (and for cluster ids that are not numbers at all).
+set.seed(7)
+ng <- 40
+gd <- data.frame(cID = rep(sample(1000:9999, ng), each = 3),
+                 x = rnorm(3 * ng))
+gd$y <- rbinom(nrow(gd), 1, plogis(.5 + .4 * gd$x + rep(rnorm(ng), each = 3)))
+
+gfit <- glmer(y ~ x + (1 | cID), data = gd, family = binomial, nAGQ = 5L)
+gs <- estfun(gfit)
+expect_true(is.matrix(gs))
+expect_equal(nrow(gs), ng)
+expect_true(all(abs(colSums(gs)) < .05))
+
+## character cluster ids
+gd$cIDc <- paste0("id", gd$cID)
+gfitc <- glmer(y ~ x + (1 | cIDc), data = gd, family = binomial, nAGQ = 5L)
+gsc <- estfun(gfitc)
+expect_equal(unname(gs), unname(gsc), tolerance = 1e-6)


### PR DESCRIPTION
## Summary

This PR resolves the two open issues.

### Issue #2 — wrong ordering of variance components in `vcov.lmerMod(full = TRUE)`

**Root cause:** `Lind` is lme4's mapping of `theta` into the slots of **`Lambdat`** (the transposed factor), not `Lambda`. `vcov.lmerMod()` and `estfun.lmerMod()` assigned `Lind` directly into `Lambda@x`:

```r
LambdaInd <- parts$Lambda
LambdaInd@x[] <- parts$Lind
```

The CSC slot order of `Lambda` (column-major within each lower-triangular block) differs from that of `Lambdat` (row-major of the same block) whenever a random-effect block is 3×3 or larger, so the derivative matrices `devLambda[[i]]`/`devV[[i]]` were attached to the wrong parameters. Concretely, values came out in row-major lower-triangle order while the labels (and the `ranpar = "sd"` chain-rule weights, which follow `VarCorr(..., order = "lower.tri")`) assume theta's column-major order. 2×2 blocks are invariant to the difference, which is why the sleepstudy-based tests never caught it.

**Fix:** fill `Lambdat` with the parameter indices and transpose, which is correct in general (including multiple grouping factors):

```r
LambdaInd <- parts$Lambdat
LambdaInd@x[] <- parts$Lind
LambdaInd <- t(LambdaInd)
```

**Verification** (see regression tests):
- The example from #2 (bdf data, `(sex + Minority | schoolNR)` vs `(Minority + sex | schoolNR)`) now agrees across formula orderings when matched by parameter names; the "wacky" reshuffle no longer matches.
- `vcov(., full = TRUE, information = "observed", ranpar = "var")` now matches the numerical Hessian (numDeriv) of a hand-coded LMM log-likelihood, and `colSums(estfun(., level = 1))` matches the numerical gradient, for a 3-dimensional random-effect model.
- All variants (`ranpar = "var"/"sd"`, ML/REML, expected/observed, cluster-robust sandwich SEs) are now invariant to the order of random effects in the formula.
- 2×2 results (sleepstudy) are unchanged, and the runnable portion of the existing tinytest suite still passes.

**Drive-by fix:** the REML + `information = "observed"` branch of `vcov.lmerMod()` filled `ranhes` from an `apply()` whose function returned 1×1 `Matrix` objects, so `apply()` produced a list and the subsequent `forceSymmetric()` failed. Wrapped the result in `as.vector()`, matching the ML branch.

### Issue #3 — `estfun.glmerMod()` "subscript out of bounds"

The reported error came from `grp = as.numeric(grpnm[j])` being used as a row index into the random-effect modes matrix inside `score.prod()`: with character cluster ids this gave `NA`, and with numeric but non-consecutive ids (e.g. real subject ids like 4711) it indexed positionally past the end of the matrix — exactly the "subscript out of bounds" surfaced through `t()`'s argument evaluation. The code fix (passing `grpnm[j]` so the row is looked up by name) is already on `master` (c118e18 for `estfun.glmerMod`, c4d6fad for `llcont.glmerMod`) but was never released to CRAN (still at 0.2-4), which is why users keep hitting it. I verified that checking out the 0.2-4 code reproduces the reported error verbatim and that current `master` does not.

This PR adds regression tests so it stays fixed: `estfun.glmerMod()` on a binomial `glmer()` fit with non-consecutive numeric cluster ids (error case), score sums near zero, and identical scores for numeric vs. character ids. Closing #3 likely also warrants a CRAN release, since the fix has been sitting unreleased since 2022.

## Test plan

- [x] New regression tests in `inst/tinytest/test-github-issues.R` (11 assertions; simulated data only, no new Suggests). They fail on the pre-fix code (3 failures) and pass after the fix.
- [x] Existing `test_merDeriv.R` checks runnable in this environment (lmer + lavaan comparison + glmer VerbAgg checks, 14 assertions) pass. The mirt/lmeInfo/smdata sections could not be run here (packages unavailable offline).
- [x] `vcov`/`estfun` validated against numDeriv gradient/Hessian of a hand-coded marginal log-likelihood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AbFyxwbU76HpN48J7QUNN

---
_Generated by [Claude Code](https://claude.ai/code/session_015AbFyxwbU76HpN48J7QUNN)_